### PR TITLE
Speed improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZoneFinder"
 uuid = "3ccf6684-3f25-4581-8c58-114637dcab4a"
 authors = ["Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,16 @@ JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
 Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 JSON3 = "1"
 Memoize = "0.4"
 Meshes = "0.23"
+Scratch = "1"
 TimeZones = "1"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Etc/GMT (UTC+0)
 
 Please see the [documentation](https://tpgillam.github.io/TimeZoneFinder.jl/stable/) for further details.
 
-## Source
+## References
 
-The underlying data is sourced from [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder), and used under the [Open Data Commons Open Database License (ODbL)](http://opendatacommons.org/licenses/odbl/).
+* The underlying data is sourced from [timezone-boundary-builder](https://github.com/evansiroky/timezone-boundary-builder), and used under the [Open Data Commons Open Database License (ODbL)](http://opendatacommons.org/licenses/odbl/).
+* The locations used in the tests are duplicated from [timezonefinder](https://github.com/jannikmi/timezonefinder), used under the MIT license.

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -11,6 +11,8 @@ using Scratch
 using Serialization
 using TimeZones
 
+const LATEST_RELEASE = "2021c"
+
 function _get_points(coord_list)::Vector{Point{2,Float64}}
     return [Point(Float64(x[1]), Float64(x[2])) for x in coord_list]
 end
@@ -123,7 +125,9 @@ Europe/Berlin (UTC+1/UTC+2)
 Returns a `TimeZone` instance if `latitude` and `longitude` correspond to a known timezone,
 otherwise `nothing` is returned.
 """
-function timezone_at(latitude::Real, longitude::Real; release::AbstractString="2021c")
+function timezone_at(
+    latitude::Real, longitude::Real; release::AbstractString=LATEST_RELEASE
+)
     data = load_data(release)
     p = Point{2,Float64}(longitude, latitude)
     # This is an unintelligent linear search through all polygons. There is much room for

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -69,6 +69,9 @@ Get the timezone at the given `latitude` and `longitude`.
 julia> timezone_at(52.5061, 13.358)
 Europe/Berlin (UTC+1/UTC+2)
 ```
+
+Returns a `TimeZone` instance if `latitude` and `longitude` correspond to a known timezone,
+otherwise `nothing` is returned.
 """
 function timezone_at(
     latitude::AbstractFloat, longitude::AbstractFloat; release::AbstractString="2021c"

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -6,6 +6,9 @@ using JSON3
 using LazyArtifacts
 using Memoize
 using Meshes
+using Pkg.TOML
+using Scratch
+using Serialization
 using TimeZones
 
 function _get_points(coord_list)::Vector{Point{2,Float64}}
@@ -28,7 +31,10 @@ function _get_shape(geometry)
     end
 end
 
-@memoize function load_data(release::AbstractString)
+"""
+Generate the timezone map data from the artifact identified by `release`.
+"""
+function generate_data(release::AbstractString)
     artifact_name = "timezone-boundary-builder-$release"
     dir = LazyArtifacts.@artifact_str(artifact_name)
     obj = open(JSON3.read, joinpath(dir, "combined-with-oceans.json"))
@@ -36,7 +42,6 @@ end
     # Vectors that will be populated in the loop below.
     shapes = []
     tzs = []
-
     foreach(obj[:features]) do feature
         # Note: Etc/<Stuff> timezones count as LEGACY timezones. These are used in the
         #   oceans, so for these purposes we allow them.
@@ -57,7 +62,52 @@ end
     shapes = identity.(shapes)
     tzs = identity.(tzs)
 
+    # Package data into a namedtuple.
     return (; shapes, tzs)
+end
+
+"""
+    _scratch_dir(release)
+
+Get the scratch directory path in which the serialized mapping data will be kept.
+"""
+function _scratch_dir(release::AbstractString)
+    # The scratch directory should be different for different package versions, since we
+    # may generate data in a different format.
+    pkg_version = VersionNumber(
+        TOML.parsefile(joinpath(dirname(@__DIR__), "Project.toml"))["version"]
+    )
+
+    # It should also be different for different Julia versions, since the serialisation
+    # protocol may change.
+    julia_version = string(VERSION)
+
+    scratch_name = "$(release)-$(pkg_version)-$(julia_version)"
+    return @get_scratch!(scratch_name)
+end
+
+"""Serialized data file path for this version."""
+_cache_path(release::AbstractString) = joinpath(_scratch_dir(release), "data.bin")
+
+"""
+    load_data(release)
+
+Load timezone map data for `release`.
+
+This is memoized, such that the data is only read from disk once within the lifetime of the
+Julia process.
+"""
+@memoize function load_data(release::AbstractString)
+    # Read data from the cache path if it exists, otherwise generate from the artifact, and
+    # cache.
+    path = _cache_path(release)
+    return if isfile(path)
+        deserialize(path)
+    else
+        data = generate_data(release)
+        serialize(path, data)
+        data
+    end
 end
 
 """
@@ -73,9 +123,7 @@ Europe/Berlin (UTC+1/UTC+2)
 Returns a `TimeZone` instance if `latitude` and `longitude` correspond to a known timezone,
 otherwise `nothing` is returned.
 """
-function timezone_at(
-    latitude::Real, longitude::Real; release::AbstractString="2021c"
-)
+function timezone_at(latitude::Real, longitude::Real; release::AbstractString="2021c")
     data = load_data(release)
     p = Point{2,Float64}(longitude, latitude)
     # This is an unintelligent linear search through all polygons. There is much room for

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -74,7 +74,7 @@ Returns a `TimeZone` instance if `latitude` and `longitude` correspond to a know
 otherwise `nothing` is returned.
 """
 function timezone_at(
-    latitude::AbstractFloat, longitude::AbstractFloat; release::AbstractString="2021c"
+    latitude::Real, longitude::Real; release::AbstractString="2021c"
 )
     data = load_data(release)
     p = Point{2,Float64}(longitude, latitude)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,122 @@ using Test
 using TimeZoneFinder
 using TimeZones
 
+"""
+    Location
+
+A test location with an expected timezone.
+"""
+struct Location
+    latitude::Float64
+    longitude::Float64
+    description::String
+    timezone::TimeZone
+end
+
+function Location(
+    latitude::Real, longitude::Real, description::AbstractString, timezone::AbstractString
+)
+    return Location(
+        Float64(latitude),
+        Float64(longitude),
+        string(description),
+        TimeZone(timezone, TimeZones.Class(:ALL)),
+    )
+end
+function Location(latitude::Real, longitude::Real, timezone::AbstractString)
+    return Location(latitude, longitude, "", timezone)
+end
+Location(args::Tuple) = Location(args...)
+
+# These test locations are duplicated from https://github.com/jannikmi/timezonefinder
+# under the MIT license.
+const TEST_LOCATIONS =
+    Location.([
+        (35.295953, -89.662186, "Arlington, TN", "America/Chicago"),
+        (35.1322601, -90.0902499, "Memphis, TN", "America/Chicago"),
+        (61.17, -150.02, "Anchorage, AK", "America/Anchorage"),
+        (40.2, -119.3, "California/Nevada border", "America/Los_Angeles"),
+        (42.652647, -73.756371, "Albany, NY", "America/New_York"),
+        (55.743749, 37.6207923, "Moscow", "Europe/Moscow"),
+        (34.104255, -118.4055591, "Los Angeles", "America/Los_Angeles"),
+        (55.743749, 37.6207923, "Moscow", "Europe/Moscow"),
+        (39.194991, -106.8294024, "Aspen, Colorado", "America/Denver"),
+        (50.438114, 30.5179595, "Kiev", "Europe/Kiev"),
+        (12.936873, 77.6909136, "Jogupalya", "Asia/Kolkata"),
+        (38.889144, -77.0398235, "Washington DC", "America/New_York"),
+        (19, -135, "pacific ocean", "Etc/GMT+9"),
+        (30, -33, "atlantic ocean", "Etc/GMT+2"),
+        (-24, 79, "indian ocean", "Etc/GMT-5"),
+        (59.932490, 30.3164291, "St Petersburg", "Europe/Moscow"),
+        (50.300624, 127.559166, "Blagoveshchensk", "Asia/Yakutsk"),
+        (42.439370, -71.0700416, "Boston", "America/New_York"),
+        (41.84937, -87.6611995, "Chicago", "America/Chicago"),
+        (28.626873, -81.7584514, "Orlando", "America/New_York"),
+        (47.610615, -122.3324847, "Seattle", "America/Los_Angeles"),
+        (51.499990, -0.1353549, "London", "Europe/London"),
+        (51.256241, -0.8186531, "Church Crookham", "Europe/London"),
+        (51.292215, -0.8002638, "Fleet", "Europe/London"),
+        (48.868743, 2.3237586, "Paris", "Europe/Paris"),
+        (22.158114, 113.5504603, "Macau", "Asia/Macau"),
+        (56.833123, 60.6097054, "Russia", "Asia/Yekaterinburg"),
+        (60.887496, 26.6375756, "Salo", "Europe/Helsinki"),
+        (52.799992, -1.8524408, "Staffordshire", "Europe/London"),
+        (5.016666, 115.0666667, "Muara", "Asia/Brunei"),
+        (-41.466666, -72.95, "Puerto Montt seaport", "America/Santiago"),
+        (34.566666, 33.0333333, "Akrotiri seaport", "Asia/Nicosia"),
+        (37.466666, 126.6166667, "Inchon seaport", "Asia/Seoul"),
+        (42.8, 132.8833333, "Nakhodka seaport", "Asia/Vladivostok"),
+        (50.26, -5.051, "Truro", "Europe/London"),
+        (37.790792, -122.389980, "San Francisco", "America/Los_Angeles"),
+        (37.81, -122.35, "San Francisco Bay", "America/Los_Angeles"),
+        (68.3597987, -133.745786, "America", "America/Inuvik"),
+        # lng 180 == -180
+        # 180.0: right on the timezone boundary polygon edge, the return value is uncertain
+        # (None in this case) being tested in test_helpers.py
+        (65.2, 179.9999, "lng 180", "Asia/Anadyr"),
+        (65.2, -179.9999, "lng -180", "Asia/Anadyr"),
+        # test cases for hole handling:
+        (41.0702284, 45.0036352, "Aserbaid. Enklave", "Asia/Yerevan"),
+        (39.8417402, 70.6020068, "Tajikistani Enklave", "Asia/Dushanbe"),
+        (47.7024174, 8.6848462, "Busingen Ger", "Europe/Busingen"),
+        (46.2085101, 6.1246227, "Genf", "Europe/Zurich"),
+        (-29.391356857138753, 28.50989829115889, "Lesotho", "Africa/Maseru"),
+        (39.93143377877638, 71.08546583764965, "Uzbek enclave1", "Asia/Tashkent"),
+        (39.969915, 71.134060, "Uzbek enclave2", "Asia/Tashkent"),
+        (39.862402, 70.568449, "Tajik enclave", "Asia/Dushanbe"),
+        (35.7396116, -110.15029571, "Arizona Desert 1", "America/Denver"),
+        (36.4091869, -110.7520236, "Arizona Desert 2", "America/Phoenix"),
+        (36.10230848, -111.1882385, "Arizona Desert 3", "America/Phoenix"),
+
+        # ocean:
+        (37.81, -123.5, "Far off San Fran.", "Etc/GMT+8"),
+        (50.26, -9.0, "Far off Cornwall", "Etc/GMT+1"),
+        (50.5, 1, "English Channel1", "Etc/GMT"),
+        (56.218, 19.4787, "baltic sea", "Etc/GMT-1"),
+
+        # boundaries:
+        (90.0, -180.0, "Etc/GMT+12"),
+        # TODO This does not pass (no timezone is found) — maybe special-casing is required,
+        # or geometry needs modifying?
+        # (0.0, -180.0, "Etc/GMT+12"),
+        (-90.0, -180.0, "Antarctica/McMurdo"),
+        (90.0, 180.0, "Etc/GMT-12"),
+        (0.0, 180.0, "Etc/GMT-12"),
+        (-90.0, 180.0, "Antarctica/McMurdo"),
+        (0.0, 179.999, "Etc/GMT-12"),
+        (0.0, -179.999, "Etc/GMT+12"),
+    ])
+
 @testset "TimeZoneFinder.jl" begin
-    @test timezone_at(52.5061, 13.358) == TimeZone("Europe/Berlin")
-    @test timezone_at(21.508, -78.215) == TimeZone("America/Havana")
-    @test timezone_at(50.5, 1.0) == TimeZone("Etc/GMT", TimeZones.Class(:LEGACY))
+    @testset "basic" begin
+        @test timezone_at(52.5061, 13.358) == TimeZone("Europe/Berlin")
+        @test timezone_at(21.508, -78.215) == TimeZone("America/Havana")
+        @test timezone_at(50.5, 1.0) == TimeZone("Etc/GMT", TimeZones.Class(:LEGACY))
+    end
+
+    @testset "known locations" begin
+        for location in TEST_LOCATIONS
+            @test timezone_at(location.latitude, location.longitude) == location.timezone
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,6 +113,7 @@ const TEST_LOCATIONS =
         @test timezone_at(52.5061, 13.358) == TimeZone("Europe/Berlin")
         @test timezone_at(21.508, -78.215) == TimeZone("America/Havana")
         @test timezone_at(50.5, 1.0) == TimeZone("Etc/GMT", TimeZones.Class(:LEGACY))
+        @test timezone_at(-89, 20) == TimeZone("Antarctica/McMurdo")
     end
 
     @testset "known locations" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,10 +121,9 @@ const TEST_LOCATIONS =
         # Clear memoize cache.
         empty!(memoize_cache(TimeZoneFinder.load_data))
 
-        if read_from_cache
-            # Ensure that binary cache exists if we expect to read from it.
-            @test isfile(TimeZoneFinder._cache_path(TimeZoneFinder.LATEST_RELEASE))
-        end
+        # Ensure that binary cache either exists or doesn't exist as we expect.
+        cache_path = TimeZoneFinder._cache_path(TimeZoneFinder.LATEST_RELEASE)
+        @test read_from_cache == isfile(cache_path)
 
         @testset "basic (read_from_cache=$read_from_cache)" begin
             # Memoize cache should be empty


### PR DESCRIPTION
 - More tests
 - Add caching of the parsed JSON (saves a lot of time after the first use of the package)
 - Allow integers to be used to specify latitude & longitude