### PR TITLE
Add support for 2022b, 2022d, 2022f tzdata releases

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,7 +1,31 @@
 [timezone-boundary-builder-2021c]
 git-tree-sha1 = "6418fde407d1c917005a96b9615ba4758ef170cb"
-lazy = false
+lazy = true
 
     [[timezone-boundary-builder-2021c.download]]
     sha256 = "297ff27da3e50b1f2b1bcb75009ed1d8aac616fec56ff1ac081021b610017d0d"
     url = "https://github.com/tpgillam/TimeZoneFinder.jl/releases/download/timezone-boundary-builder-2021c/timezone-boundary-builder-2021c.tar.gz"
+
+[timezone-boundary-builder-2022b]
+git-tree-sha1 = "fe7eee9ec0f981eb34fd268e17150273d1442dac"
+lazy = true
+
+    [[timezone-boundary-builder-2022b.download]]
+    sha256 = "7abdf814632a20399bcc688de3e69a38e0c9f6d3b08d67f5584caa27cf5cb86b"
+    url = "https://github.com/tpgillam/TimeZoneFinder.jl/releases/download/timezone-boundary-builder-2022b/timezone-boundary-builder-2022b.tar.gz"
+
+[timezone-boundary-builder-2022d]
+git-tree-sha1 = "928337e2a168ac0efbde0f95e414dc991c741e95"
+lazy = true
+
+    [[timezone-boundary-builder-2022d.download]]
+    sha256 = "2d4affa97700cbeae9d6166a225ec899dc4896c1ff32fe35a916cecf7dfcda08"
+    url = "https://github.com/tpgillam/TimeZoneFinder.jl/releases/download/timezone-boundary-builder-2022d/timezone-boundary-builder-2022d.tar.gz"
+
+[timezone-boundary-builder-2022f]
+git-tree-sha1 = "651b8f30bc4a601937df84d2d9c8f1029dcd47e6"
+lazy = false
+
+    [[timezone-boundary-builder-2022f.download]]
+    sha256 = "50a41b7f574d12429e5591a3583777a38434395af1e9dd6ee28bef019a841fff"
+    url = "https://github.com/tpgillam/TimeZoneFinder.jl/releases/download/timezone-boundary-builder-2022f/timezone-boundary-builder-2022f.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ JSON3 = "1"
 Memoize = "0.4"
 Meshes = "0.23, 0.24, 0.25, 0.26"
 Scratch = "1"
-TimeZones = "1"
+TimeZones = "1.9.1"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZoneFinder"
 uuid = "3ccf6684-3f25-4581-8c58-114637dcab4a"
 authors = ["Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.1.3"
+version = "0.2.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/artifact_build/create.jl
+++ b/artifact_build/create.jl
@@ -6,7 +6,7 @@ using Tar
 
 # This script assumes that the `unzip` command is available on the command line.
 
-release = "2021c"
+release = "2022f"
 
 # This is the name of the artifact that we're creating.
 artifact_name = "timezone-boundary-builder-$release"

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -11,7 +11,7 @@ using Scratch
 using Serialization
 using TimeZones
 
-const LATEST_RELEASE = "2021c"
+const LATEST_RELEASE = "2022f"
 
 function _get_points(coord_list)::Vector{Point{2,Float64}}
     return [Point(Float64(x[1]), Float64(x[2])) for x in coord_list]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -43,7 +43,7 @@ const TEST_LOCATIONS =
         (34.104255, -118.4055591, "Los Angeles", "America/Los_Angeles"),
         (55.743749, 37.6207923, "Moscow", "Europe/Moscow"),
         (39.194991, -106.8294024, "Aspen, Colorado", "America/Denver"),
-        (50.438114, 30.5179595, "Kiev", "Europe/Kiev"),
+        (50.438114, 30.5179595, "Kyiv", "Europe/Kyiv"),
         (12.936873, 77.6909136, "Jogupalya", "Asia/Kolkata"),
         (38.889144, -77.0398235, "Washington DC", "America/New_York"),
         (19, -135, "pacific ocean", "Etc/GMT+9"),
@@ -136,7 +136,8 @@ const TEST_LOCATIONS =
 
             @test timezone_at(21.508, -78.215) == TimeZone("America/Havana")
             @test timezone_at(50.5, 1.0) == TimeZone("Etc/GMT", TimeZones.Class(:LEGACY))
-            @test timezone_at(-89, 20) == TimeZone("Antarctica/McMurdo")
+            @test timezone_at(-89, 20) ==
+                TimeZone("Antarctica/McMurdo", TimeZones.Class(:LEGACY))
 
             # Invalid locations shouldn't have a corresponding timezone.
             @test isnothing(timezone_at(91, 0))


### PR DESCRIPTION
Currently this cannot be merged, as it is reliant on a new tag of TimeZones.jl (which adds support for new time zones).