### PR TITLE
Decouple boundary version from tzdata version

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -24,7 +24,7 @@ lazy = true
 
 [timezone-boundary-builder-2022f]
 git-tree-sha1 = "651b8f30bc4a601937df84d2d9c8f1029dcd47e6"
-lazy = false
+lazy = true
 
     [[timezone-boundary-builder-2022f.download]]
     sha256 = "50a41b7f574d12429e5591a3583777a38434395af1e9dd6ee28bef019a841fff"
@@ -40,7 +40,7 @@ lazy = true
 
 [timezone-boundary-builder-2023b]
 git-tree-sha1 = "062c3da562b49ed8cebb528ed29582f3f52aa17f"
-lazy = true
+lazy = false
 
     [[timezone-boundary-builder-2023b.download]]
     sha256 = "0883cafe32408169d29a3fe3c57da3e185b40e1b20e783fc7924e249f481d9cf"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZoneFinder"
 uuid = "3ccf6684-3f25-4581-8c58-114637dcab4a"
 authors = ["Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -84,6 +84,7 @@ end
     _scratch_dir(version)
 
 Get the scratch directory path in which the serialized mapping data will be kept.
+`version` here refers to the version of the boundary data.
 """
 function _scratch_dir(version::AbstractString)
     # The scratch directory should be different for different package versions, since we
@@ -125,6 +126,43 @@ Julia process.
 end
 
 """
+    _get_boundary_builder_versions()
+
+Get a list of versions for we have boundary data. Will be e.g. `["2022a", "2023b"]`.
+
+The list will be sorted in order of increasing versions.
+"""
+function _get_boundary_builder_versions()
+    toml = TOML.parsefile(find_artifacts_toml(@__FILE__))
+    return sort!([last(split(name, "-")) for name in keys(toml)])
+end
+
+
+"""
+    _timezone_boundary_builder_version()
+    _timezone_boundary_builder_version(tzdata_version)
+
+Get the version of timezone-boundary-builder data that we should use.
+
+If no arguments are provided, the `tzdata_version` is determined by that currently in use by
+the `TimeZones` package. The map from tzdata version -> boundary version is memoized.
+
+This is determined by the rules in the "note" in the docstring for `timezone_at`.
+"""
+@memoize function _timezone_boundary_builder_version(tzdata_version::AbstractString)
+    boundary_builder_versions = _get_boundary_builder_versions()
+
+    i = searchsortedlast(boundary_builder_versions, tzdata_version)
+    iszero(i) && throw(ArgumentError("No boundary data available for $tzdata_version"))
+    return boundary_builder_versions[i]
+end
+
+function _timezone_boundary_builder_version()
+    tzdata_version = TimeZones.TZData.tzdata_version()
+    return _timezone_boundary_builder_version(tzdata_version)
+end
+
+"""
     timezone_at(latitude, longitude)
 
 Get the timezone at the given `latitude` and `longitude`.
@@ -135,13 +173,23 @@ Europe/Berlin (UTC+1/UTC+2)
 ```
 
 !!! note
-    The library always uses the same version of tzdata currently used by `TimeZones`.
+    The library will use a version of the timezone-boundary-builder data that is compatible
+    with the version of tzdata currently used by `TimeZones`.
+
+    Nominally this will be the _same_ version as is used by `TimeZones`, but in some cases
+    an older version might be used.
+
+    There are two possible reasons for this:
+
+        1. There were no boundary changes in a tzdata release, which means that there will
+            never be a boundary release for this particular version.
+        2. The boundary dataset is not yet available for a new tzdata release.
 
 Returns a `TimeZone` instance if `latitude` and `longitude` correspond to a known timezone,
 otherwise `nothing` is returned.
 """
 function timezone_at(latitude::Real, longitude::Real)
-    version = TimeZones.TZData.tzdata_version()
+    version = _timezone_boundary_builder_version()
     data = load_data(version)
     p = Point{2,Float64}(longitude, latitude)
     # This is an unintelligent linear search through all polygons. There is much room for

--- a/src/TimeZoneFinder.jl
+++ b/src/TimeZoneFinder.jl
@@ -137,7 +137,6 @@ function _get_boundary_builder_versions()
     return sort!([last(split(name, "-")) for name in keys(toml)])
 end
 
-
 """
     _timezone_boundary_builder_version()
     _timezone_boundary_builder_version(tzdata_version)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using Memoize
 using Test
 using TimeZoneFinder
+using TimeZoneFinder: _timezone_boundary_builder_version
 using TimeZones
-using TimeZones.TZData: tzdata_version
 
 """
     Location
@@ -143,14 +143,14 @@ const TEST_LOCATIONS =
     # in-memory Memoize cache is cleared, but read from the binary file.
 
     # Clear binary cache directory.
-    rm(TimeZoneFinder._scratch_dir(tzdata_version()); recursive=true)
+    rm(TimeZoneFinder._scratch_dir(_timezone_boundary_builder_version()); recursive=true)
 
     for read_from_cache in (false, true)
         # Clear memoize cache.
         empty!(memoize_cache(TimeZoneFinder.load_data))
 
         # Ensure that binary cache either exists or doesn't exist as we expect.
-        cache_path = TimeZoneFinder._cache_path(tzdata_version())
+        cache_path = TimeZoneFinder._cache_path(_timezone_boundary_builder_version())
         @test read_from_cache == isfile(cache_path)
 
         @testset "basic (read_from_cache=$read_from_cache)" begin


### PR DESCRIPTION
Closes #21, #24 

This implements a fallback, such that we use the most recent version of boundary data available that is <= the tzdata version from `TimeZones.jl`

This is the "simple" solution for #21. It also solves #24 