### PR TITLE
Handle region overlap with new API

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.6'
-          - '1.8'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeZoneFinder"
 uuid = "3ccf6684-3f25-4581-8c58-114637dcab4a"
 authors = ["Tom Gillam <tpgillam@googlemail.com>"]
-version = "0.3.5"
+version = "0.4.0"
 
 [deps]
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,6 +5,7 @@ Documentation for [TimeZoneFinder](https://github.com/tpgillam/TimeZoneFinder.jl
 ## API
 
 ```@docs
+timezones_at
 timezone_at
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,6 +158,7 @@ const TEST_LOCATIONS =
             @test isempty(memoize_cache(TimeZoneFinder.load_data))
 
             @test timezone_at(52.5061, 13.358) == TimeZone("Europe/Berlin")
+            @test timezones_at(52.5061, 13.358) == [TimeZone("Europe/Berlin")]
 
             # Memoize cache should now be populated
             @test !isempty(memoize_cache(TimeZoneFinder.load_data))
@@ -171,6 +172,9 @@ const TEST_LOCATIONS =
             @test isnothing(timezone_at(91, 0))
             @test isnothing(timezone_at(0, 181))
             @test isnothing(timezone_at(0, -181))
+            @test isempty(timezones_at(91, 0))
+            @test isempty(timezones_at(0, 181))
+            @test isempty(timezones_at(0, -181))
         end
 
         @testset "known locations (read_from_cache=$read_from_cache)" begin
@@ -178,6 +182,15 @@ const TEST_LOCATIONS =
                 @test timezone_at(location.latitude, location.longitude) ==
                     location.timezone
             end
+        end
+
+        @testset "multiple timezones (read_from_cache=$read_from_cache)" begin
+            # This is the disputed Beaufort sea region.
+            # Taken from timezone-boundary-builder. Full list of expected overlaps are here:
+            #   https://github.com/evansiroky/timezone-boundary-builder/blob/master/expectedZoneOverlaps.json
+            @test timezones_at(69.8, -141) ==
+                [TimeZone("America/Anchorage"), TimeZone("America/Dawson")]
+            @test_throws ArgumentError timezone_at(69.8, -141)
         end
     end
 


### PR DESCRIPTION
Closes #22 

Introduces the `timezones_at` function, which will not throw, but can return an empty list of timezones, or multiple timezones, for given coordinates.